### PR TITLE
Make startScan() async and check BLE availability

### DIFF
--- a/packages/quick_blue/lib/quick_blue.dart
+++ b/packages/quick_blue/lib/quick_blue.dart
@@ -15,7 +15,7 @@ class QuickBlue {
   static Future<bool> isBluetoothAvailable() =>
       _platform.isBluetoothAvailable();
 
-  static void startScan() => _platform.startScan();
+  static Future<void> startScan() => _platform.startScan();
 
   static void stopScan() => _platform.stopScan();
 

--- a/packages/quick_blue/lib/src/method_channel_quick_blue.dart
+++ b/packages/quick_blue/lib/src/method_channel_quick_blue.dart
@@ -34,14 +34,14 @@ class MethodChannelQuickBlue extends QuickBluePlatform {
 
   @override
   Future<void> startScan() async {
-    _method.invokeMethod('startScan')
-        .then((_) => _log('startScan invokeMethod success'));
+    await _method.invokeMethod('startScan');
+    _log('startScan invokeMethod success');
   }
 
   @override
-  void stopScan() {
-    _method.invokeMethod('stopScan')
-        .then((_) => _log('stopScan invokeMethod success'));
+  Future<void> stopScan() async {
+    await _method.invokeMethod('startScan');
+    _log('startScan invokeMethod success');
   }
 
   final Stream<dynamic> _scanResultStream = _eventScanResult.receiveBroadcastStream({'name': 'scanResult'});

--- a/packages/quick_blue/lib/src/method_channel_quick_blue.dart
+++ b/packages/quick_blue/lib/src/method_channel_quick_blue.dart
@@ -33,7 +33,7 @@ class MethodChannelQuickBlue extends QuickBluePlatform {
   }
 
   @override
-  void startScan() {
+  Future<void> startScan() async {
     _method.invokeMethod('startScan')
         .then((_) => _log('startScan invokeMethod success'));
   }

--- a/packages/quick_blue/lib/src/quick_blue_linux.dart
+++ b/packages/quick_blue/lib/src/quick_blue_linux.dart
@@ -60,7 +60,7 @@ class QuickBlueLinux extends QuickBluePlatform {
   }
 
   @override
-  void stopScan() async {
+  Future<void> stopScan() async {
     await _ensureInitialized();
     _log('stopScan invoke success');
 

--- a/packages/quick_blue/lib/src/quick_blue_linux.dart
+++ b/packages/quick_blue/lib/src/quick_blue_linux.dart
@@ -51,7 +51,7 @@ class QuickBlueLinux extends QuickBluePlatform {
   }
 
   @override
-  void startScan() async {
+  Future<void> startScan() async {
     await _ensureInitialized();
     _log('startScan invoke success');
 

--- a/packages/quick_blue/lib/src/quick_blue_platform_interface.dart
+++ b/packages/quick_blue/lib/src/quick_blue_platform_interface.dart
@@ -35,7 +35,7 @@ abstract class QuickBluePlatform extends PlatformInterface {
 
   Future<bool> isBluetoothAvailable();
 
-  void startScan();
+  Future<void> startScan();
 
   void stopScan();
 

--- a/packages/quick_blue/lib/src/quick_blue_platform_interface.dart
+++ b/packages/quick_blue/lib/src/quick_blue_platform_interface.dart
@@ -37,7 +37,7 @@ abstract class QuickBluePlatform extends PlatformInterface {
 
   Future<void> startScan();
 
-  void stopScan();
+  Future<void> stopScan();
 
   Stream<dynamic> get scanResultStream;
 

--- a/packages/quick_blue/windows/quick_blue_plugin.cpp
+++ b/packages/quick_blue/windows/quick_blue_plugin.cpp
@@ -222,12 +222,20 @@ void QuickBluePlugin::HandleMethodCall(
   if (method_name.compare("isBluetoothAvailable") == 0) {
     result->Success(EncodableValue(bluetoothRadio && bluetoothRadio.State() == RadioState::On));
   } else if (method_name.compare("startScan") == 0) {
-    if (!bluetoothLEWatcher) {
-      bluetoothLEWatcher = BluetoothLEAdvertisementWatcher();
-      bluetoothLEWatcherReceivedToken = bluetoothLEWatcher.Received({ this, &QuickBluePlugin::BluetoothLEWatcher_Received });
-    }
-    bluetoothLEWatcher.Start();
-    result->Success(nullptr);
+
+      if (bluetoothRadio.State() != RadioState::On)
+      {
+          result->Error("Bluetooth isn't currently turned on");
+      }
+      else
+      {
+          if (!bluetoothLEWatcher) {
+              bluetoothLEWatcher = BluetoothLEAdvertisementWatcher();
+              bluetoothLEWatcherReceivedToken = bluetoothLEWatcher.Received({ this, &QuickBluePlugin::BluetoothLEWatcher_Received });
+          }
+          bluetoothLEWatcher.Start();
+          result->Success(nullptr);
+      }
   } else if (method_name.compare("stopScan") == 0) {
     if (bluetoothLEWatcher) {
       bluetoothLEWatcher.Stop();

--- a/packages/quick_blue/windows/quick_blue_plugin.cpp
+++ b/packages/quick_blue/windows/quick_blue_plugin.cpp
@@ -222,10 +222,15 @@ void QuickBluePlugin::HandleMethodCall(
   if (method_name.compare("isBluetoothAvailable") == 0) {
     result->Success(EncodableValue(bluetoothRadio && bluetoothRadio.State() == RadioState::On));
   } else if (method_name.compare("startScan") == 0) {
-
-      if (bluetoothRadio.State() != RadioState::On)
+    // Are there any Bluetooth adapters on the computer that could service this request?
+		if (bluetoothRadio == nullptr)
+		{
+            result->Error("No available adapters to be used for BLE.");
+		}
+    // Is the Bluetooth switch enabled on the host OS?
+      else if (bluetoothRadio.State() != RadioState::On)
       {
-          result->Error("Bluetooth isn't currently turned on");
+          result->Error("Bluetooth isn't currently turned on.");
       }
       else
       {


### PR DESCRIPTION
On Windows, if `startScan()` is called while the Bluetooth switch is in the "off" state, quick_blue causes a native crash.

This PR first checks that Bluetooth is enabled, and if it is not, returns an error back up to the Flutter system to deal with.

It also changes the implementation of `startScan` to `async`. That's because, in my tests, it seems like the error was only caught properly if `startScan` was made async.

EDIT: Also check if the bluetooth adapter is available before trying to use it. It's possible that the bluetooth object could be null if there was no eligible hardware to be used on the computer.