### PR TITLE
Delay Bluetooth permission prompt on iOS until it is really needed

### DIFF
--- a/packages/quick_blue/darwin/QuickBlueDarwin.swift
+++ b/packages/quick_blue/darwin/QuickBlueDarwin.swift
@@ -60,17 +60,14 @@ public class QuickBlueDarwin: NSObject, FlutterPlugin {
     instance.messageConnector = messageConnector
   }
 
-  private var manager: CBCentralManager!
+  private lazy var manager: CBCentralManager = {
+      discoveredPeripherals = Dictionary()
+    return CBCentralManager(delegate: self, queue: nil)
+  }()
   private var discoveredPeripherals: Dictionary<String, CBPeripheral>!
 
   private var scanResultSink: FlutterEventSink?
   private var messageConnector: FlutterBasicMessageChannel!
-
-  override init() {
-    super.init()
-    manager = CBCentralManager(delegate: self, queue: nil)
-    discoveredPeripherals = Dictionary()
-  }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {

--- a/packages/quick_blue/darwin/QuickBlueDarwin.swift
+++ b/packages/quick_blue/darwin/QuickBlueDarwin.swift
@@ -61,7 +61,7 @@ public class QuickBlueDarwin: NSObject, FlutterPlugin {
   }
 
   private lazy var manager: CBCentralManager = {
-      discoveredPeripherals = Dictionary()
+    discoveredPeripherals = Dictionary()
     return CBCentralManager(delegate: self, queue: nil)
   }()
   private var discoveredPeripherals: Dictionary<String, CBPeripheral>!


### PR DESCRIPTION
This change delays Bluetooth permission prompt on iOS until it is really needed. It is needed to make apps conform to Apple's HIG. You can test it if you remove:

```dart
            FutureBuilder(
              future: QuickBlue.isBluetoothAvailable(),
              builder: (context, snapshot) {
                var available = snapshot.data?.toString() ?? '...';
                return Text('Bluetooth init: $available');
              },
            ),
```
from the example app. You will only get the permission prompt when you tap on startScan.