### PR TITLE
Initialize discoveredPeripherals eagerly

### DIFF
--- a/packages/quick_blue/darwin/QuickBlueDarwin.swift
+++ b/packages/quick_blue/darwin/QuickBlueDarwin.swift
@@ -60,11 +60,8 @@ public class QuickBlueDarwin: NSObject, FlutterPlugin {
     instance.messageConnector = messageConnector
   }
 
-  private lazy var manager: CBCentralManager = {
-    discoveredPeripherals = Dictionary()
-    return CBCentralManager(delegate: self, queue: nil)
-  }()
-  private var discoveredPeripherals: Dictionary<String, CBPeripheral>!
+  private lazy var manager: CBCentralManager = { CBCentralManager(delegate: self, queue: nil) }()
+  private var discoveredPeripherals = Dictionary<String, CBPeripheral>()
 
   private var scanResultSink: FlutterEventSink?
   private var messageConnector: FlutterBasicMessageChannel!


### PR DESCRIPTION
Followup PR to my previous one.  `DiscoveredPeripherals` need to be initialized eagerly otherwise calling disconnect before any other call causes a nil exception.