### PR TITLE
Improve "requestPermission"

### DIFF
--- a/packages/quick_usb/README.md
+++ b/packages/quick_usb/README.md
@@ -7,7 +7,8 @@ A cross-platform (Android/Windows/macOS/Linux) USB plugin for Flutter
 - [List devices](#list-devices)
 - [List devices with additional description](#list-devices-with-additional-description)
 - [Get device description](#get-device-description)
-- [Check/Request permission](#checkrequest-permission)
+- [Check permission](#check-permission)
+- [Request permission](#request-permission)
 - [Open/Close device](#openclose-device)
 - [Get/Set configuration](#getset-configuration)
 - [Claim/Release interface](#claimrelease-interface)
@@ -59,15 +60,25 @@ for permission for each device if needed. If you do not require the serial numbe
 var description = await QuickUsb.getDeviceDescription(requestPermission: false);
 ```
 
-### Check/Request permission
+### Check permission
 
 _**Android Only**_
 
 ```dart
 var hasPermission = await QuickUsb.hasPermission(device);
 print('hasPermission $hasPermission');
-// ...
-await QuickUsb.requestPermission(device);
+```
+
+### Request permission
+
+_**Android Only**_
+
+Request permission for a device. The permission dialog is not shown
+if the app already has permission to access the device.
+
+```dart
+var hasPermission = await QuickUsb.requestPermission(device);
+print('hasPermission $hasPermission');
 ```
 
 ### Open/Close device

--- a/packages/quick_usb/android/src/main/kotlin/com/example/quick_usb/QuickUsbPlugin.kt
+++ b/packages/quick_usb/android/src/main/kotlin/com/example/quick_usb/QuickUsbPlugin.kt
@@ -121,7 +121,6 @@ class QuickUsbPlugin : FlutterPlugin, MethodCallHandler {
           context.registerReceiver(receiver, IntentFilter(ACTION_USB_PERMISSION))
           manager.requestPermission(device, pendingPermissionIntent(context))
         }
-        result.success(null)
       }
       "openDevice" -> {
         val manager = usbManager ?: return result.error("IllegalState", "usbManager null", null)

--- a/packages/quick_usb/android/src/main/kotlin/com/example/quick_usb/QuickUsbPlugin.kt
+++ b/packages/quick_usb/android/src/main/kotlin/com/example/quick_usb/QuickUsbPlugin.kt
@@ -17,8 +17,8 @@ import io.flutter.plugin.common.MethodChannel.Result
 private const val ACTION_USB_PERMISSION = "com.example.quick_usb.USB_PERMISSION"
 
 private val pendingIntentFlag =
-  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
   } else {
     PendingIntent.FLAG_UPDATE_CURRENT
   }
@@ -51,17 +51,6 @@ class QuickUsbPlugin : FlutterPlugin, MethodCallHandler {
 
   private var usbDevice: UsbDevice? = null
   private var usbDeviceConnection: UsbDeviceConnection? = null
-
-  private val receiver = object : BroadcastReceiver() {
-    override fun onReceive(context: Context, intent: Intent) {
-      context.unregisterReceiver(this)
-      val device = intent.getParcelableExtra<UsbDevice>(UsbManager.EXTRA_DEVICE)
-      val granted = intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)
-      if (!granted) {
-        println("Permission denied: ${device?.deviceName}")
-      }
-    }
-  }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
     when (call.method) {
@@ -118,7 +107,17 @@ class QuickUsbPlugin : FlutterPlugin, MethodCallHandler {
         val manager = usbManager ?: return result.error("IllegalState", "usbManager null", null)
         val identifier = call.argument<String>("identifier")
         val device = manager.deviceList[identifier]
-        if (!manager.hasPermission(device)) {
+        if (manager.hasPermission(device)) {
+          result.success(true)
+        } else {
+          val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+              context.unregisterReceiver(this)
+              val usbDevice = intent.getParcelableExtra<UsbDevice>(UsbManager.EXTRA_DEVICE)
+              val granted = intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)
+              result.success(granted);
+            }
+          }
           context.registerReceiver(receiver, IntentFilter(ACTION_USB_PERMISSION))
           manager.requestPermission(device, pendingPermissionIntent(context))
         }

--- a/packages/quick_usb/lib/quick_usb.dart
+++ b/packages/quick_usb/lib/quick_usb.dart
@@ -37,7 +37,7 @@ class QuickUsb {
   static Future<bool> hasPermission(UsbDevice usbDevice) =>
       _platform.hasPermission(usbDevice);
 
-  static Future<void> requestPermission(UsbDevice usbDevice) =>
+  static Future<bool> requestPermission(UsbDevice usbDevice) =>
       _platform.requestPermission(usbDevice);
 
   static Future<bool> openDevice(UsbDevice usbDevice) =>

--- a/packages/quick_usb/lib/src/quick_usb_android.dart
+++ b/packages/quick_usb/lib/src/quick_usb_android.dart
@@ -67,8 +67,8 @@ class QuickUsbAndroid extends QuickUsbPlatform {
   }
 
   @override
-  Future<void> requestPermission(UsbDevice usbDevice) {
-    return _channel.invokeMethod('requestPermission', usbDevice.toMap());
+  Future<bool> requestPermission(UsbDevice usbDevice) async {
+    return await _channel.invokeMethod('requestPermission', usbDevice.toMap());
   }
 
   @override

--- a/packages/quick_usb/lib/src/quick_usb_desktop.dart
+++ b/packages/quick_usb/lib/src/quick_usb_desktop.dart
@@ -160,8 +160,8 @@ class _QuickUsbDesktop extends QuickUsbPlatform {
   }
 
   @override
-  Future<void> requestPermission(UsbDevice usbDevice) async {
-    return;
+  Future<bool> requestPermission(UsbDevice usbDevice) async {
+    return true;
   }
 
   @override

--- a/packages/quick_usb/lib/src/quick_usb_platform_interface.dart
+++ b/packages/quick_usb/lib/src/quick_usb_platform_interface.dart
@@ -36,7 +36,7 @@ abstract class QuickUsbPlatform extends PlatformInterface {
 
   Future<bool> hasPermission(UsbDevice usbDevice);
 
-  Future<void> requestPermission(UsbDevice usbDevice);
+  Future<bool> requestPermission(UsbDevice usbDevice);
 
   Future<bool> openDevice(UsbDevice usbDevice);
 


### PR DESCRIPTION
Improve "requestPermission"

- "requestPermission" method returns with the permission after it has been accepted/rejected.
- Bug-fix Android intent flags when requesting permissions (see https://github.com/woodemi/quick_usb/issues/66)