### PR TITLE
Initialize CBCentralManager when listening for availability changes

### DIFF
--- a/packages/quick_blue/README.md
+++ b/packages/quick_blue/README.md
@@ -12,7 +12,7 @@ A cross-platform (Android/iOS/macOS/Windows/Linux) BluetoothLE plugin for Flutte
 
 | API | Android | iOS | macOS | Windows | Linux |
 | :--- | :---: | :---: | :---: | :---: | :---: |
-| setAvailabilityHandler |  | ✔️ | ✔️ |  |  |
+| availabilityChangeStream |  | ✔️ | ✔️ |  |  |
 | isBluetoothAvailable | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 | startScan/stopScan | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 | connect/disconnect | ✔️ | ✔️ | ✔️ | ✔️ |  |
@@ -28,11 +28,9 @@ A cross-platform (Android/iOS/macOS/Windows/Linux) BluetoothLE plugin for Flutte
 
 iOS/macOS
 ```dart
-QuickBlue.setAvailabilityHandler(_handleAvailabilityChange);
-
-void _handleAvailabilityChange(AvailabilityState state) {
-  debugPrint('_handleAvailabilityChange ${state.value}');
-}
+QuickBlue.availabilityChangeStream.listen((state) {
+  debugPrint('Bluetooth state: ${state.toString()}');
+});
 ```
 
 

--- a/packages/quick_blue/lib/quick_blue.dart
+++ b/packages/quick_blue/lib/quick_blue.dart
@@ -23,11 +23,12 @@ class QuickBlue {
   static Future<bool> isBluetoothAvailable() =>
       _platform.isBluetoothAvailable();
 
-  static void setAvailabilityHandler(OnAvailabilityChanged? onAvailabilityChanged) {
+  static Stream<AvailabilityState> get availabilityChangeStream {
     if (!Platform.isIOS && !Platform.isMacOS) {
       throw UnimplementedError('setAvailabilityHandler is only implemented on iOS and macOS');
     }
-    _platform.onAvailabilityChanged = onAvailabilityChanged;
+    return _platform.availabilityChangeStream
+        .map((availabilityStateValue) => AvailabilityState.parse(availabilityStateValue));
   }
 
   static Future<void> startScan() => _platform.startScan();

--- a/packages/quick_blue/lib/src/method_channel_quick_blue.dart
+++ b/packages/quick_blue/lib/src/method_channel_quick_blue.dart
@@ -9,6 +9,7 @@ import 'quick_blue_platform_interface.dart';
 class MethodChannelQuickBlue extends QuickBluePlatform {
   static const _method = MethodChannel('quick_blue/method');
   static const _eventScanResult = EventChannel('quick_blue/event.scanResult');
+  static const _eventAvailabilityChange = EventChannel('quick_blue/event.availabilityChange');
   static const _messageConnector = BasicMessageChannel('quick_blue/message.connector', StandardMessageCodec());
 
   MethodChannelQuickBlue() {
@@ -31,6 +32,11 @@ class MethodChannelQuickBlue extends QuickBluePlatform {
     bool result = await _method.invokeMethod('isBluetoothAvailable');
     return result;
   }
+
+  final Stream<int> _availabilityChangeStream = _eventAvailabilityChange.receiveBroadcastStream({'name': 'availabilityChange'}).cast();
+
+  @override
+  Stream<int> get availabilityChangeStream => _availabilityChangeStream;
 
   @override
   Future<void> startScan() async {
@@ -72,10 +78,7 @@ class MethodChannelQuickBlue extends QuickBluePlatform {
 
   Future<void> _handleConnectorMessage(dynamic message) async {
     _log('_handleConnectorMessage $message', logLevel: Level.ALL);
-    if (message['AvailabilityState'] != null) {
-      AvailabilityState availabilityState = AvailabilityState.parse(message['AvailabilityState']);
-      onAvailabilityChanged?.call(availabilityState);
-    } else if (message['ConnectionState'] != null) {
+    if (message['ConnectionState'] != null) {
       String deviceId = message['deviceId'];
       BlueConnectionState connectionState = BlueConnectionState.parse(message['ConnectionState']);
       onConnectionChanged?.call(deviceId, connectionState);

--- a/packages/quick_blue/lib/src/models.dart
+++ b/packages/quick_blue/lib/src/models.dart
@@ -28,6 +28,26 @@ class AvailabilityState {
     }
     throw ArgumentError.value(value);
   }
+
+  @override
+  String toString() {
+    switch (this) {
+      case AvailabilityState.unknown:
+        return 'unknown';
+      case AvailabilityState.resetting:
+        return 'resetting';
+      case AvailabilityState.unsupported:
+        return 'unsupported';
+      case AvailabilityState.unauthorized:
+        return 'unauthorized';
+      case AvailabilityState.poweredOff:
+        return 'poweredOff';
+      case AvailabilityState.poweredOn:
+        return 'poweredOn';
+      default:
+        throw ArgumentError.value(value);
+    }
+  }
 }
 
 class BlueScanResult {

--- a/packages/quick_blue/lib/src/quick_blue_linux.dart
+++ b/packages/quick_blue/lib/src/quick_blue_linux.dart
@@ -57,6 +57,10 @@ class QuickBlueLinux extends QuickBluePlatform {
   }
 
   @override
+  // TODO: implement availabilityChangeStream
+  Stream<int> get availabilityChangeStream => throw UnimplementedError();
+
+  @override
   Future<void> startScan() async {
     await _ensureInitialized();
     _log('startScan invoke success');

--- a/packages/quick_blue/lib/src/quick_blue_platform_interface.dart
+++ b/packages/quick_blue/lib/src/quick_blue_platform_interface.dart
@@ -9,8 +9,6 @@ import 'models.dart';
 export 'method_channel_quick_blue.dart';
 export 'models.dart';
 
-typedef OnAvailabilityChanged = void Function(AvailabilityState availabilityState);
-
 typedef QuickLogger = Logger;
 
 typedef OnConnectionChanged = void Function(String deviceId, BlueConnectionState state);
@@ -33,11 +31,11 @@ abstract class QuickBluePlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  OnAvailabilityChanged? onAvailabilityChanged;
-
   void setLogger(QuickLogger logger);
 
   Future<bool> isBluetoothAvailable();
+
+  Stream<int> get availabilityChangeStream;
 
   Future<void> startScan();
 


### PR DESCRIPTION
This PR addresses https://github.com/woodemi/quick.flutter/issues/42.