### PR TITLE
Fix quick_blue_linux.dart not working

### DIFF
--- a/packages/quick_blue/lib/src/quick_blue_linux.dart
+++ b/packages/quick_blue/lib/src/quick_blue_linux.dart
@@ -25,11 +25,12 @@ class QuickBlueLinux extends QuickBluePlatform {
       await _client.connect();
 
       _activeAdapter ??= _client.adapters.firstWhereOrNull((adapter) => adapter.powered);
-      if (_activeAdapter != null && _client.adapters.isNotEmpty) {
-        await _client.adapters.first.setPowered(true);
-        _activeAdapter = _client.adapters.first;
-      } else {
-        throw Exception('Bluetooth adapter unavailable');
+      if (_activeAdapter == null) {
+          if (_client.adapters.isEmpty) {
+             throw Exception('Bluetooth adapter unavailable');
+          }
+          await _client.adapters.first.setPowered(true);
+          _activeAdapter = _client.adapters.first;
       }
       _client.deviceAdded.listen(_onDeviceAdd);
 

--- a/packages/quick_blue/lib/src/quick_blue_linux.dart
+++ b/packages/quick_blue/lib/src/quick_blue_linux.dart
@@ -25,7 +25,7 @@ class QuickBlueLinux extends QuickBluePlatform {
       await _client.connect();
 
       _activeAdapter ??= _client.adapters.firstWhereOrNull((adapter) => adapter.powered);
-      if (_activeAdapter == null && _client.adapters.isNotEmpty) {
+      if (_activeAdapter != null && _client.adapters.isNotEmpty) {
         await _client.adapters.first.setPowered(true);
         _activeAdapter = _client.adapters.first;
       } else {


### PR DESCRIPTION
I went to test out quick_blue for linux support and first tried the other version "woodemi/quick_blue" which didn't have support for connecting/disconnecting so I came here to do it instead. The example in the quick_blue repo worked fine but when I tried this one it would throw an exception that no bluetooth adapter was found. I had a look at the code and noticed replaced the _ensureInitialized() with the one from the old repo, and it worked fine. I done some testing and fixed the `if (_activeAdapter == null && _client.adapters.isNotEmpty) {` line by changing it to `if (_activeAdapter != null && _client.adapters.isNotEmpty) {`. That is what this pull request is for.