### PR TITLE
A14 (API34) Support

### DIFF
--- a/packages/quick_usb/android/build.gradle
+++ b/packages/quick_usb/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/quick_usb/android/src/main/kotlin/com/example/quick_usb/QuickUsbPlugin.kt
+++ b/packages/quick_usb/android/src/main/kotlin/com/example/quick_usb/QuickUsbPlugin.kt
@@ -18,7 +18,7 @@ private const val ACTION_USB_PERMISSION = "com.example.quick_usb.USB_PERMISSION"
 
 private val pendingIntentFlag =
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-    PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+    PendingIntent.FLAG_MUTABLE  or PendingIntent.FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT or PendingIntent.FLAG_UPDATE_CURRENT
   } else {
     PendingIntent.FLAG_UPDATE_CURRENT
   }
@@ -86,7 +86,12 @@ class QuickUsbPlugin : FlutterPlugin, MethodCallHandler {
               ))
             }
           }
-          context.registerReceiver(permissionReceiver, IntentFilter(ACTION_USB_PERMISSION))
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+              context.registerReceiver(permissionReceiver, IntentFilter(ACTION_USB_PERMISSION),
+                  Context.RECEIVER_EXPORTED)
+          }else {
+              context.registerReceiver(permissionReceiver, IntentFilter(ACTION_USB_PERMISSION));
+          }
           manager.requestPermission(device, pendingPermissionIntent(context))
         } else {
           result.success(mapOf(
@@ -118,7 +123,12 @@ class QuickUsbPlugin : FlutterPlugin, MethodCallHandler {
               result.success(granted);
             }
           }
-          context.registerReceiver(receiver, IntentFilter(ACTION_USB_PERMISSION))
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+              context.registerReceiver(receiver, IntentFilter(ACTION_USB_PERMISSION),
+                  Context.RECEIVER_EXPORTED)
+          }else {
+              context.registerReceiver(receiver, IntentFilter(ACTION_USB_PERMISSION));
+          }
           manager.requestPermission(device, pendingPermissionIntent(context))
         }
       }


### PR DESCRIPTION
RECEIVER_EXPORTED now required for registering receiver on A14. 
Updated sdkversion.

Very minimal changes.